### PR TITLE
Add basic support for ChangesFeed

### DIFF
--- a/changes.go
+++ b/changes.go
@@ -1,0 +1,163 @@
+// +build js
+
+package pouchdb
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/gopherjs/gopherjs/js"
+	"github.com/gopherjs/jsbuiltin"
+)
+
+// ChangesFeed is an iterator for database changes. See https://pouchdb.com/api.html#changes
+// On each call to the Next method, the event fields are updated for the current
+// event. Next is designed to be used in a for loop:
+//
+//     feed, err := client.Changes("db", nil)
+//         ...
+//         for feed.Next() {
+//             fmt.Printf("changed: %s", feed.ID)
+//         }
+//         err = feed.Err()
+//         ...
+type ChangesFeed struct {
+	// DB is the database. Since all events in a _changes feed
+	// belong to the same database, this field is always equivalent to the
+	// database from the DB.Changes call that created the feed object
+	DB *PouchDB
+
+	// ID is the document ID of the current event.
+	ID string
+
+	// Deleted is true when the event represents a deleted document.
+	Deleted bool
+
+	// Seq is the database update sequence number of the current event.
+	// After all items have been processed, set to the last_seq value sent
+	// by CouchDB.
+	Seq string
+
+	// Changes is the list of the document's leaf revisions.
+	Changes []struct {
+		Rev string
+	}
+
+	// The document. This is populated only if the feed option
+	// "include_docs" is true.
+	Doc json.RawMessage
+
+	closed    bool
+	err       error
+	changes   *js.Object
+	sendEvent chan<- event
+	readEvent <-chan event
+	results   []*js.Object
+}
+
+// Close closes the changesfeed and frees up any allocated resources. Note that
+// this should be called even for one-shot feed operations.
+func (cf *ChangesFeed) Close() error {
+	fmt.Printf("Cancelling\n")
+	cf.changes.Call("cancel")
+	close(cf.sendEvent)
+	cf.closed = true
+	return nil
+}
+
+func (cf *ChangesFeed) Err() error {
+	return cf.err
+}
+
+// Next populates the feed with the next value. Note that order is not
+// guaranteed. If you need events in a specific order, please refer to the
+// sequence ID.
+func (cf *ChangesFeed) Next() bool {
+	if cf.closed {
+		return false
+	}
+	if cf.results != nil {
+		if cf.nextResult() {
+			// If false, continue, in case we received events out of order
+			return true
+		}
+	}
+	e := <-cf.readEvent
+
+	switch e.EventType {
+	case "change":
+		return cf.next(e.Object)
+	case "complete":
+		r := e.Object.Get("results")
+		cf.results = make([]*js.Object, r.Length())
+		for i := 0; i < r.Length(); i++ {
+			cf.results[i] = r.Index(i)
+		}
+		// If false, it means there were no results, so there's no chance of
+		// having received events out of order.
+		return cf.nextResult()
+	case "error":
+		cf.err = &js.Error{Object: e.Object}
+		return false
+	}
+
+	return false
+}
+
+func (cf *ChangesFeed) next(o *js.Object) bool {
+	cf.ID = o.Get("id").String()
+	cf.Deleted = o.Get("deleted").Bool()
+	cf.Seq = o.Get("seq").String()
+	if changes := o.Get("changes"); jsbuiltin.TypeOf(changes) != "undefined" {
+		cf.Changes = make([]struct {
+			Rev string
+		}, changes.Length())
+		for i := 0; i < changes.Length(); i++ {
+			cf.Changes[i].Rev = changes.Index(i).Get("rev").String()
+		}
+	}
+
+	return true
+}
+
+func (cf *ChangesFeed) nextResult() bool {
+	if len(cf.results) == 0 {
+		cf.results = nil
+		return false
+	}
+	var o *js.Object
+	o, cf.results = cf.results[0], cf.results[1:]
+	return cf.next(o)
+}
+
+type event struct {
+	EventType string
+	Object    *js.Object
+}
+
+func (db *PouchDB) Changes(opts Options) (*ChangesFeed, error) {
+	eChan := make(chan event)
+	cf := &ChangesFeed{
+		DB:        db,
+		changes:   db.Call("changes", opts.compile()),
+		sendEvent: eChan,
+		readEvent: eChan,
+	}
+	cf.changes.Call("on", "change", func(o *js.Object) {
+		go cf.handleEvent("change", o)
+	})
+	// cf.changes.Call("on", "complete", func(o *js.Object) {
+	// 	go cf.handleEvent("complete", o)
+	// })
+	cf.changes.Call("on", "error", func(o *js.Object) {
+		go cf.handleEvent("error", o)
+	})
+	return cf, nil
+}
+
+func (cf *ChangesFeed) handleEvent(eventType string, o *js.Object) {
+	cf.sendEvent <- event{
+		EventType: eventType,
+		Object:    o,
+	}
+}

--- a/changes_test.go
+++ b/changes_test.go
@@ -1,0 +1,152 @@
+// +build js
+
+package pouchdb
+
+import (
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+)
+
+func TestNoChanges(t *testing.T) {
+	db := newPouch("changes")
+	cf, err := db.Changes(Options{})
+	if err != nil {
+		t.Fatalf("Error opening changes feed: %s", err)
+	}
+	var count int
+	expectedCount := 0
+	for cf.Next() {
+		count++
+	}
+	if count != expectedCount {
+		t.Errorf("Got %d results, expected %d\n", count, expectedCount)
+	}
+	if err = cf.Err(); err != nil {
+		t.Fatalf("Error reading changes: %s", err)
+	}
+}
+
+func feedsEqual(f1, f2 *ChangesFeed) bool {
+	if f1.ID != f2.ID {
+		return false
+	}
+	if f1.Deleted != f2.Deleted {
+		return false
+	}
+	if f1.Seq != f2.Seq {
+		return false
+	}
+	if len(f1.Changes) != len(f2.Changes) {
+		return false
+	}
+	for i := range f1.Changes {
+		parts1 := strings.Split(f1.Changes[i].Rev, "-")
+		parts2 := strings.Split(f2.Changes[i].Rev, "-")
+		if parts1[0] != parts2[0] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestChanges(t *testing.T) {
+	db := newPouch("changes")
+	cf, err := db.Changes(Options{})
+	if err != nil {
+		t.Fatalf("Error opening changes feed: %s", err)
+	}
+	var count int
+	expectedCount := 1
+	expectedResults := []*ChangesFeed{
+		&ChangesFeed{
+			DB:      db,
+			ID:      "foobar",
+			Deleted: true,
+			Changes: []struct {
+				Rev string
+			}{
+				struct {
+					Rev string
+				}{
+					Rev: "2-xxx",
+				},
+			},
+			Seq: "2",
+		},
+	}
+
+	doc := map[string]interface{}{
+		"_id": "foobar",
+		"foo": "bar",
+	}
+	rev, err := db.Put(doc)
+	if err != nil {
+		t.Fatalf("Error storing document: %s", err)
+	}
+	doc["_rev"] = rev
+	if _, err = db.Remove(doc, Options{}); err != nil {
+		t.Fatalf("Error deleting document: %s", err)
+	}
+
+	cf, err = db.Changes(Options{
+		Style: AllDocs,
+		Limit: expectedCount,
+	})
+	if err != nil {
+		t.Fatalf("Error opening changes feed: %s", err)
+	}
+
+	for cf.Next() {
+		expected := expectedResults[count]
+		if !feedsEqual(expected, cf) {
+			fmt.Printf("Result %d not as expected.\n\tExpected: %+v\n\t  Actual: %+v\n", count+1, expected, cf)
+		}
+		count++
+	}
+	if count != expectedCount {
+		t.Errorf("Got %d results, expected %d\n", count, expectedCount)
+	}
+	if err = cf.Err(); err != nil {
+		t.Fatalf("Error reading changes: %s", err)
+	}
+
+}
+
+func xTestLiveChanges(t *testing.T) {
+	fmt.Printf("x\n")
+	db := newPouch("changes")
+	cf, err := db.Changes(Options{
+		Live: true,
+	})
+	defer cf.Close()
+
+	fmt.Printf("y\n")
+	if err != nil {
+		t.Fatalf("Error opening changes feed: %s", err)
+	}
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		fmt.Printf("z\n")
+		for cf.Next() {
+			fmt.Printf("zz\n")
+			spew.Dump(cf)
+		}
+		fmt.Printf("a\n")
+		if err := cf.Err(); err != nil {
+			t.Fatalf("Error reading changes: %s", err)
+		}
+
+	}()
+	fmt.Printf("sleeping\n")
+	time.Sleep(1 * time.Second)
+	fmt.Printf("waiting\n")
+	wg.Wait()
+	fmt.Printf("Done waiting\n")
+}

--- a/changes_test.go
+++ b/changes_test.go
@@ -5,11 +5,7 @@ package pouchdb
 import (
 	"fmt"
 	"strings"
-	"sync"
 	"testing"
-	"time"
-
-	"github.com/davecgh/go-spew/spew"
 )
 
 func TestNoChanges(t *testing.T) {
@@ -117,36 +113,36 @@ func TestChanges(t *testing.T) {
 
 }
 
-func xTestLiveChanges(t *testing.T) {
-	fmt.Printf("x\n")
-	db := newPouch("changes")
-	cf, err := db.Changes(Options{
-		Live: true,
-	})
-	defer cf.Close()
-
-	fmt.Printf("y\n")
-	if err != nil {
-		t.Fatalf("Error opening changes feed: %s", err)
-	}
-	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		fmt.Printf("z\n")
-		for cf.Next() {
-			fmt.Printf("zz\n")
-			spew.Dump(cf)
-		}
-		fmt.Printf("a\n")
-		if err := cf.Err(); err != nil {
-			t.Fatalf("Error reading changes: %s", err)
-		}
-
-	}()
-	fmt.Printf("sleeping\n")
-	time.Sleep(1 * time.Second)
-	fmt.Printf("waiting\n")
-	wg.Wait()
-	fmt.Printf("Done waiting\n")
-}
+// func xTestLiveChanges(t *testing.T) {
+// 	fmt.Printf("x\n")
+// 	db := newPouch("changes")
+// 	cf, err := db.Changes(Options{
+// 		Live: true,
+// 	})
+// 	defer cf.Close()
+//
+// 	fmt.Printf("y\n")
+// 	if err != nil {
+// 		t.Fatalf("Error opening changes feed: %s", err)
+// 	}
+// 	var wg sync.WaitGroup
+// 	wg.Add(1)
+// 	go func() {
+// 		defer wg.Done()
+// 		fmt.Printf("z\n")
+// 		for cf.Next() {
+// 			fmt.Printf("zz\n")
+// 			spew.Dump(cf)
+// 		}
+// 		fmt.Printf("a\n")
+// 		if err := cf.Err(); err != nil {
+// 			t.Fatalf("Error reading changes: %s", err)
+// 		}
+//
+// 	}()
+// 	fmt.Printf("sleeping\n")
+// 	time.Sleep(1 * time.Second)
+// 	fmt.Printf("waiting\n")
+// 	wg.Wait()
+// 	fmt.Printf("Done waiting\n")
+// }

--- a/options.go
+++ b/options.go
@@ -113,7 +113,7 @@ type Options struct {
 
 	// Maximum number of documents to return.
 	//
-	// Used by AllDocs() and Query()
+	// Used by AllDocs(), Query() and Changes().
 	Limit int
 
 	// Number of docs to skip before returning.
@@ -225,7 +225,25 @@ type Options struct {
 	//
 	// Used by Query().
 	Stale string
+
+	// Live sets continuous changes feed operation.
+	//
+	// Used by Changes().
+	Live bool
+
+	// Style specifies how many revisions are returned in the changes array.
+	Style FeedStyle
 }
+
+type FeedStyle string
+
+const (
+	// MainOnly only shows the winning revision in the changes feed.
+	MainOnly FeedStyle = "main_only"
+	// AllDocs returns all leaf revisions (including conflicts and deleted
+	// former conflicts) in the changes feed
+	AllDocs FeedStyle = "all_docs"
+)
 
 func (o *Options) compile() map[string]interface{} {
 	opts := make(map[string]interface{})
@@ -345,6 +363,12 @@ func (o *Options) compile() map[string]interface{} {
 	}
 	if o.Stale != "" {
 		opts["stale"] = o.Stale
+	}
+	if o.Live {
+		opts["live"] = true
+	}
+	if o.Style != FeedStyle("") {
+		opts["style"] = o.Style
 	}
 	return opts
 }

--- a/pouchdb_test.go
+++ b/pouchdb_test.go
@@ -212,6 +212,9 @@ func TestAttachments(t *testing.T) {
 		t.Fatal("PutAttachment() returned a 0-byte rev")
 	}
 	att2, err := db.Attachment("foo", "foo.txt", "")
+	if err != nil {
+		t.Fatalf("Error fetching attachment: %s", err)
+	}
 	buf := new(bytes.Buffer)
 	buf.ReadFrom(att2.Body)
 	body2 := buf.String()


### PR DESCRIPTION
This provides the basic functionality for the ChangesFeed, in response to #42. It is not yet tested with live feeds, or the majority of configuration options.