### PR TITLE
Rework Find() API to be more useable.

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -49,7 +49,7 @@ func ErrorName(err error) string {
 	return ""
 }
 
-// ErrorName returns the reason portion of a PouchError, or "" for other errors
+// ErrorReason returns the reason portion of a PouchError, or "" for other errors
 func ErrorReason(err error) string {
 	switch pe := err.(type) {
 	case *PouchError:
@@ -99,4 +99,23 @@ func NewPouchError(err *js.Error) error {
 // Underlying returns the underlying js.Error object, as returned from the PouchDB library
 func (e *PouchError) Underlying() *js.Error {
 	return e.e
+}
+
+// Warning represents a non-fatal PouchDB warning.
+type Warning struct {
+	Message string
+}
+
+func (w *Warning) Error() string {
+	return "WARNING: " + w.Message
+}
+
+// IsWarning returns true of the error message is a PouchDB warning, otherwise
+// false.
+func IsWarning(err error) bool {
+	switch err.(type) {
+	case *Warning:
+		return true
+	}
+	return false
 }

--- a/plugins/find/find_test.go
+++ b/plugins/find/find_test.go
@@ -118,7 +118,7 @@ func TestFind(t *testing.T) {
 		t.Fatalf("Error calling Put(): %s", err)
 	}
 
-	var resultDoc map[string]interface{}
+	var results []map[string]interface{}
 	req := map[string]interface{}{
 		"selector": map[string]string{
 			"name": "Bob",
@@ -129,21 +129,19 @@ func TestFind(t *testing.T) {
 			"size",
 		},
 	}
-	expectedResult := map[string]interface{}{
-		"docs": []interface{}{
-			map[string]interface{}{
-				"_id":  "12345",
-				"name": "Bob",
-				"size": float64(48),
-			},
+	expectedResults := []map[string]interface{}{
+		map[string]interface{}{
+			"_id":  "12345",
+			"name": "Bob",
+			"size": float64(48),
 		},
 	}
-	err = db.Find(req, &resultDoc)
+	err = db.Find(req, &results)
 	if err != nil {
 		t.Fatalf("Error executing Find(): %s", err)
 	}
-	if !reflect.DeepEqual(expectedResult, resultDoc) {
-		DumpDiff(expectedResult, resultDoc)
+	if !reflect.DeepEqual(expectedResults, results) {
+		DumpDiff(expectedResults, results)
 		t.Fatal()
 	}
 

--- a/pouchdb.go
+++ b/pouchdb.go
@@ -33,11 +33,11 @@ type DBInfo struct {
 var GlobalPouch *js.Object
 
 func globalPouch() *js.Object {
-	if GlobalPouch != nil && jsbuiltin.TypeOf(GlobalPouch) != "undefined" {
+	if GlobalPouch != nil && GlobalPouch != js.Undefined {
 		return GlobalPouch
 	}
 	GlobalPouch = js.Global.Get("PouchDB")
-	if jsbuiltin.TypeOf(GlobalPouch) == "undefined" {
+	if GlobalPouch == js.Undefined {
 		GlobalPouch = js.Global.Call("require", "pouchdb")
 	}
 	return GlobalPouch


### PR DESCRIPTION
This changes the find plugin's `Find()` function signature to be (IMO) more intuitive. It now decodes the "docs" portion of the reply directly into the passed argument, negating the need for the caller to extract that.